### PR TITLE
Include z3c.autoinclude.plugin entry point 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,7 @@ setup(name='diazotheme.bootstrap',
       ],
       entry_points="""
       # -*- Entry points: -*-
+      [z3c.autoinclude.plugin]
+      target = plone
       """,
       )


### PR DESCRIPTION
to avoid the need to update buildout zcml directive when installing this product.
