### PR TITLE
Update diazotheme/bootstrap/configure.zcml

### DIFF
--- a/diazotheme/bootstrap/configure.zcml
+++ b/diazotheme/bootstrap/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     >
 
+  <include package="Products.CMFCore" file="permissions.zcml" />
+
   <plone:static directory="static" type="theme" />
 
   <genericsetup:registerProfile


### PR DESCRIPTION
Without this I get

zope.configuration.config.ConfigurationExecutionError: <class 'zope.component.interfaces.ComponentLookupError'>: (<InterfaceClass zope.security.interfaces.IPermission>, u'cmf.ManagePortal')
  in:
  File "/path/to/instance/src/diazotheme.bootstrap/diazotheme/bootstrap/portlet/configure.zcml", line 7.4-16.6
      <plone:portlet
          name="diazotheme.bootstrap.portlet.carousel"
          interface=".carousel.ICarouselPortlet"
          assignment=".carousel.Assignment"
          view_permission="zope2.View"
          edit_permission="cmf.ManagePortal"
          renderer=".carousel.Renderer"
          addview=".carousel.AddForm"
          editview=".carousel.EditForm"
      />
