### PR TITLE
Disable responsive css for print

### DIFF
--- a/diazotheme/bootstrap/static/base.html
+++ b/diazotheme/bootstrap/static/base.html
@@ -27,7 +27,7 @@
       <link rel="stylesheet" href="css/public.css"/>
       <link rel="stylesheet" href="css/reset.css"/>
       <link rel="stylesheet" href="bootstrap/css/bootstrap.min.css"/>
-      <link rel="stylesheet" href="bootstrap/css/bootstrap-responsive.min.css"/>
+      <link rel="stylesheet" href="bootstrap/css/bootstrap-responsive.min.css" media="screen"/>
 
       <link rel="stylesheet" href="openid-selector/css/openid.css"/>
       <link rel="stylesheet" href="css/theme.css"/>


### PR DESCRIPTION
If the responsive css is enabled on print media a 21 cm page the page is considered 595 pixels wide and thus rendered the same as the smallest devices.
See
http://stackoverflow.com/questions/12246096/bootstrap-printing-width/12250808#12250808
